### PR TITLE
Change the text size for the frontend app to be larger

### DIFF
--- a/AstroFrontEnd/public/global.css
+++ b/AstroFrontEnd/public/global.css
@@ -5,11 +5,12 @@ html, body {
 }
 
 body {
-	color: #333;
+	color: green;
 	margin: 0;
 	padding: 8px;
 	box-sizing: border-box;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.5em;
 }
 
 a {


### PR DESCRIPTION
Related to #2

Increase the text size and change the text color in the frontend app.

* Increase the `font-size` property of the `body` element to 1.5em.
* Change the `color` property of the `body` element to green.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dylan-mccarthy/GHCopilot-FontendWithBackupAPIDemo/pull/4?shareId=d7ad43e7-bf45-4a56-b2c9-a14beee7a2cc).