### PR TITLE
Change the text size and color for the frontend app

### DIFF
--- a/AstroFrontEnd/public/global.css
+++ b/AstroFrontEnd/public/global.css
@@ -5,11 +5,12 @@ html, body {
 }
 
 body {
-	color: #333;
+	color: green;
 	margin: 0;
 	padding: 8px;
 	box-sizing: border-box;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 1.5em; /* 1.5x original value */
 }
 
 a {


### PR DESCRIPTION
Related to #2

Increase the text size and change the text color in the frontend app.

* Increase the `font-size` property in the `body` selector to 1.5 times its original value.
* Change the `color` property in the `body` selector to `green`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dylan-mccarthy/GHCopilot-FontendWithBackupAPIDemo/pull/6?shareId=2150891d-204c-40d0-8736-040edbd0695b).