### PR TITLE
Increase text size and change color to green

### DIFF
--- a/AstroFrontEnd/public/global.css
+++ b/AstroFrontEnd/public/global.css
@@ -5,11 +5,12 @@ html, body {
 }
 
 body {
-	color: #333;
+	color: green;
 	margin: 0;
 	padding: 8px;
 	box-sizing: border-box;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 2.25em;
 }
 
 a {


### PR DESCRIPTION
Related to #2

Increase the text size and change the text color in the frontend app.

* Increase the `font-size` property in the `body` selector to 2.25em.
* Change the `color` property in the `body` selector to green.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dylan-mccarthy/GHCopilot-FontendWithBackupAPIDemo/pull/10?shareId=91acf5e9-f583-40f9-842b-bac3309df952).