### PR TITLE
Update frontend styles to increase text size and change color

### DIFF
--- a/AstroFrontEnd/public/global.css
+++ b/AstroFrontEnd/public/global.css
@@ -5,11 +5,12 @@ html, body {
 }
 
 body {
-	color: #333;
+	color: green;
 	margin: 0;
 	padding: 8px;
 	box-sizing: border-box;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 18px;
 }
 
 a {
@@ -94,3 +95,7 @@ main {
   th {
     background-color: #eee;
   }
+
+h1, h2, h3, h4, h5, h6 {
+	color: white;
+}

--- a/AstroFrontEnd/src/App.svelte
+++ b/AstroFrontEnd/src/App.svelte
@@ -10,9 +10,16 @@
 		<Link to="planets">Planets</Link>
 		<Link to="moons">Moons</Link>
 	</nav>
-	<div>
+	<div class="main-container">
 		<Route path="/"></Route>
 		<Route path="planets" component={Planets} />
 		<Route path="moons" component={Moons} />
 	</div>
 </Router>
+
+<style>
+	.main-container {
+		font-size: 18px;
+		color: green;
+	}
+</style>

--- a/AstroFrontEnd/src/Planets.svelte
+++ b/AstroFrontEnd/src/Planets.svelte
@@ -33,30 +33,39 @@
     onMount(fetchPlanets);
   </script>
   
-  <h1>Planets ({planets.length})</h1>
+  <div class="main-container">
+    <h1>Planets ({planets.length})</h1>
   
-  <form on:submit={addPlanet}>
-    <label>
-      Name:
-      <input type="text" name="name" required>
-    </label>
-    <label>
-      Description:
-      <textarea name="description" required></textarea>
-    </label>
-    <label>
-      Distance from Sun (in millions of kilometers):
-      <input type="number" name="distanceFromSun" required>
-    </label>
-    <button type="submit">Add Planet</button>
-  </form>
+    <form on:submit={addPlanet}>
+      <label>
+        Name:
+        <input type="text" name="name" required>
+      </label>
+      <label>
+        Description:
+        <textarea name="description" required></textarea>
+      </label>
+      <label>
+        Distance from Sun (in millions of kilometers):
+        <input type="number" name="distanceFromSun" required>
+      </label>
+      <button type="submit">Add Planet</button>
+    </form>
   
-  <ul>
-    {#each planets as planet}
-      <li>
-        <h2>{planet.name}</h2>
-        <p>{planet.description}</p>
-        <p>Distance from Sun: {planet.distanceFromSun} million km</p>
-      </li>
-    {/each}
-  </ul>
+    <ul>
+      {#each planets as planet}
+        <li>
+          <h2>{planet.name}</h2>
+          <p>{planet.description}</p>
+          <p>Distance from Sun: {planet.distanceFromSun} million km</p>
+        </li>
+      {/each}
+    </ul>
+  </div>
+  
+  <style>
+    .main-container {
+      font-size: 18px;
+      color: green;
+    }
+  </style>


### PR DESCRIPTION
Related to #15

Increase the text size and change the color to green on the main page.

* Modify `AstroFrontEnd/public/global.css` to set the text color to green and increase the font size to 18px for the `body` element. Ensure all heading elements (`h1`, `h2`, `h3`, `h4`, `h5`, `h6`) have white color.
* Update `AstroFrontEnd/src/App.svelte` to add a class to the main container to apply the global styles.
* Update `AstroFrontEnd/src/Planets.svelte` to add a class to the main container to apply the global styles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dylan-mccarthy/GHCopilot-FontendWithBackupAPIDemo/pull/16?shareId=aa8bf319-7391-4c3d-a527-81fdbc0cd40d).