### PR TITLE
Update main page text size and color

### DIFF
--- a/AstroFrontEnd/public/global.css
+++ b/AstroFrontEnd/public/global.css
@@ -5,11 +5,16 @@ html, body {
 }
 
 body {
-	color: #333;
+	color: green;
+	font-size: 18px;
 	margin: 0;
 	padding: 8px;
 	box-sizing: border-box;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	color: white;
 }
 
 a {


### PR DESCRIPTION
Fixes #18

Update the main page text to be larger and green, and change the heading colors to white.

* Modify the `body` selector in `AstroFrontEnd/public/global.css` to include `font-size: 18px;` and `color: green;`.
* Add a new selector for `h1`, `h2`, `h3`, `h4`, `h5`, `h6` in `AstroFrontEnd/public/global.css` to set the color to white.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dylan-mccarthy/GHCopilot-FontendWithBackupAPIDemo/pull/19?shareId=7397b0a5-4e24-4f45-b11c-6d5c53526fd7).