### PR TITLE
Fix text styling

### DIFF
--- a/AstroFrontEnd/public/global.css
+++ b/AstroFrontEnd/public/global.css
@@ -5,11 +5,16 @@ html, body {
 }
 
 body {
-	color: #333;
+	color: green;
+	font-size: 20px;
 	margin: 0;
 	padding: 8px;
 	box-sizing: border-box;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	color: white;
 }
 
 a {


### PR DESCRIPTION
Fixes #21

Update text color and size in `AstroFrontEnd/public/global.css`.

* Change the `color` property of the `body` selector to `green`.
* Add the `font-size` property to the `body` selector and set it to `20px`.
* Add a new selector for `h1`, `h2`, `h3`, `h4`, `h5`, and `h6` and set their `color` property to `white`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dylan-mccarthy/GHCopilot-FontendWithBackupAPIDemo/pull/22?shareId=81510551-bf17-490e-91ea-ff5035b4794c).